### PR TITLE
Fix portability issues in kazoo-haproxy scripts

### DIFF
--- a/system/sbin/kazoo-haproxy
+++ b/system/sbin/kazoo-haproxy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -f /etc/default/haproxy ]; then
 	. /etc/default/haproxy
@@ -42,7 +42,7 @@ start() {
 		return
 	fi
 
-	if echo "show stat" | nc -U $SOCKET > /dev/null 2>&1; then
+	if echo "show stat" | ncat -U $SOCKET > /dev/null 2>&1; then
 		echo "HAProxy is already running!"
 		return
 	fi
@@ -80,7 +80,7 @@ status() {
 	local STATS="pxname svname qcur qmax scur smax slim stot bin bout dreq dresp ereq econ eresp wretr wredis status weight act bck chkfail chdown lastchg downtime qlimit pid iid sid throttle lbtot tracked type rate rate_lim rate_max check_status check_code check_duration hrsp_1xx hrsp_2xx hrsp_3xx hrsp_4xx hrsp_5xx hrsp_other hanafail req_rate req_rate_max req_tot cli_abrt srv_abrt"
 	local TABLE_HEADER="Host|25 Backend|15 Status Active Rate 1xx 2xx 3xx 4xx 5xx Ping"
 	local TABLE_VARS="svname|25 pxname|15 status scur req_rate hrsp_1xx hrsp_2xx hrsp_3xx hrsp_4xx hrsp_5xx check_duration"
-	if ! echo "show stat" | nc -U $SOCKET > /dev/null 2>&1; then
+	if ! echo "show stat" | ncat -U $SOCKET > /dev/null 2>&1; then
 		echo "Unable to connect to HAProxy, ensure it is running!"
 		return
 	fi
@@ -96,7 +96,7 @@ status() {
 		printf "%-${SIZE}s |" $NAME
 	done
 	echo
-	echo "show stat" | nc -U $SOCKET \
+	echo "show stat" | ncat -U $SOCKET \
 	  | while IFS=',' read ${STATS}; do
 		if [ -z "$svname" ]; then
 			continue

--- a/system/sbin/kazoo-haproxy
+++ b/system/sbin/kazoo-haproxy
@@ -48,7 +48,7 @@ start() {
 	fi
 
 	set -- ${BIN_FILE} -f ${CFG_FILE} -p ${PID_FILE} ${OPTIONS} "$@"
-	if [ "$(whoami)" == "${USER}" ]; then
+	if [ "$(whoami)" = "${USER}" ]; then
 		exec "$@"
 	else
 		runuser -s /bin/bash ${USER} -c "$*"
@@ -101,13 +101,13 @@ status() {
 		if [ -z "$svname" ]; then
 			continue
 		fi
-		if [ "$svname" == 'svname' ]; then
+		if [ "$svname" = 'svname' ]; then
 			continue
 		fi
-		if [ "$svname" == 'BACKEND' ]; then
+		if [ "$svname" = 'BACKEND' ]; then
 			continue
 		fi
-		if [ "$svname" == 'FRONTEND' ]; then
+		if [ "$svname" = 'FRONTEND' ]; then
 			continue
 		fi
 		echo -n "|"
@@ -120,7 +120,7 @@ status() {
 				SIZE=6
 			fi
 			eval VALUE=\$$NAME
-			if [ "${VAR}" == 'check_duration' ]; then
+			if [ "${VAR}" = 'check_duration' ]; then
 				VALUE="${VALUE}ms"
 			fi
 			printf "%-${SIZE}s |" ${VALUE:-0}


### PR DESCRIPTION
This script was causing an error on Debian 8:

    kazoo-haproxy[50720]: /usr/sbin/kazoo-haproxy: 51: [: root: unexpected operator

The reason for the error is that the script is run under `/bin/sh`,
and the line with the error was

    if [ "$(whoami)" == "${USER}" ]; then

In `sh`, the `[` operator is a synonym for `test`. The above statement
is therefore equivalent to

    if test "$(whoami)" == "${USER}"; then

The problem is that the `sh` version of `test` - at least, in Debian 8,
in which `/bin/sh` is a softlink to `/bin/dash` - requires  a single `=`
for string comparisons; the `==` operator is only supported by `bash`
`test` (although see below).

It is interesting to note that when tested in macOS 10.11.6 and CentOS
7.5, this was not treated as an error. In CentOS 7, `/bin/sh` is
softlinked to `/bin/bash`, so that kind of makes sense, but it's not in
macOS. In any case, it appears that Debian `dash` sticks more closely to
the original Bourne shell version of `test` than the other two OSes.

Probably the best fix is to use the `=` operator instead, as follows:

    if [ "$(whoami)" = "${USER}" ]; then

which is equivalent to

    if test "$(whoami)" = "${USER}"; then

and is most likely valid syntax on all `sh` versions.

This commit changes all the uses of the `==` operator to `=`.