### PR TITLE
Fix some portability issues

### DIFF
--- a/system/sbin/kazoo-haproxy
+++ b/system/sbin/kazoo-haproxy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -f /etc/default/haproxy ]; then
 	. /etc/default/haproxy
@@ -42,7 +42,7 @@ start() {
 		return
 	fi
 
-	if echo "show stat" | nc -U $SOCKET > /dev/null 2>&1; then
+	if echo "show stat" | ncat -U $SOCKET > /dev/null 2>&1; then
 		echo "HAProxy is already running!"
 		return
 	fi
@@ -80,7 +80,7 @@ status() {
 	local STATS="pxname svname qcur qmax scur smax slim stot bin bout dreq dresp ereq econ eresp wretr wredis status weight act bck chkfail chdown lastchg downtime qlimit pid iid sid throttle lbtot tracked type rate rate_lim rate_max check_status check_code check_duration hrsp_1xx hrsp_2xx hrsp_3xx hrsp_4xx hrsp_5xx hrsp_other hanafail req_rate req_rate_max req_tot cli_abrt srv_abrt"
 	local TABLE_HEADER="Host|25 Backend|15 Status Active Rate 1xx 2xx 3xx 4xx 5xx Ping"
 	local TABLE_VARS="svname|25 pxname|15 status scur req_rate hrsp_1xx hrsp_2xx hrsp_3xx hrsp_4xx hrsp_5xx check_duration"
-	if ! echo "show stat" | nc -U $SOCKET > /dev/null 2>&1; then
+	if ! echo "show stat" | ncat -U $SOCKET > /dev/null 2>&1; then
 		echo "Unable to connect to HAProxy, ensure it is running!"
 		return
 	fi
@@ -96,7 +96,7 @@ status() {
 		printf "%-${SIZE}s |" $NAME
 	done
 	echo
-	echo "show stat" | nc -U $SOCKET \
+	echo "show stat" | ncat -U $SOCKET \
 	  | while IFS=',' read ${STATS}; do
 		if [ -z "$svname" ]; then
 			continue


### PR DESCRIPTION
There are two portability issues addressed in this commit:

1. Specifying the shebang as `#!/bin/sh` and then using Bashisms
2. A clash between the meaning of `nc` on Debian and CentOS

## Shebang

Running `systemctl start kazoo-haproxy` on Debian 8 resulted in this
error:

    /usr/sbin/kazoo-haproxy: 51: [: root: unexpected operator

The reason for the error is that the script's shebang is `#!/bin/sh`,
which has different behavior on Debian 8 compared to CentOS 7.

In CentOS 7, `/bin/sh` is symlinked to `/bin/bash`, but on Debian 8,
it's symlinked to `/bin/dash`, which behaves more like the original
Bourne shell, `sh`.

`sh` (and `dash`) supports `=`, but not `==`, as a string comparison
operator, hence the error.

The choices considered for this fix were:

1. Change all occurrences of `==` to`=`
2. Change the shebang to `#!/bin/bash`

This commit changes the shebang.

An earlier version of this PR chose option #1 above, but that was before
discovering that the rest of the script had many Bashisms.

## `nc` vs `ncat`

- On CentOS, `nc` is another way of running `ncat`.
- On Debian, `nc` is `netcat`, a totally different utility.

Fortunately, both respond to `ncat`, so this commit changes all uses of
`nc` to `ncat`.