### PR TITLE
Add portability fixes to 4.2

### DIFF
--- a/system/sbin/kazoo-haproxy
+++ b/system/sbin/kazoo-haproxy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -f /etc/default/haproxy ]; then
 	. /etc/default/haproxy
@@ -23,6 +23,17 @@ check_socket() {
     SOCKET=/tmp/haproxy.sock
 }
 
+# e.g. echo 'show stat' | send_socket $SOCKET
+send_socket() {
+    local socket="$1"
+    socat stdio unix-connect:${socket}
+}
+
+show_stat() {
+    local socket="$1"
+    echo 'show stat' | send_socket ${socket}
+}
+
 prepare() {
 	mkdir -p /var/log/haproxy
 	chown -R ${USER} /var/log/haproxy
@@ -42,13 +53,13 @@ start() {
 		return
 	fi
 
-	if echo "show stat" | nc -U $SOCKET > /dev/null 2>&1; then
+	if show_stat $SOCKET > /dev/null 2>&1; then
 		echo "HAProxy is already running!"
 		return
 	fi
 
 	set -- ${BIN_FILE} -f ${CFG_FILE} -p ${PID_FILE} ${OPTIONS} "$@"
-	if [ "$(whoami)" == "${USER}" ]; then
+	if [ "$(whoami)" = "${USER}" ]; then
 		exec "$@"
 	else
 		runuser -s /bin/bash ${USER} -c "$*"
@@ -62,7 +73,7 @@ start() {
 }
 
 stop() {
-	kill $(cat ${PID_FILE})
+	[[ -f "${PID_FILE}" ]] && kill $(cat ${PID_FILE})
 	RETVAL=$?
 }
 
@@ -80,7 +91,7 @@ status() {
 	local STATS="pxname svname qcur qmax scur smax slim stot bin bout dreq dresp ereq econ eresp wretr wredis status weight act bck chkfail chdown lastchg downtime qlimit pid iid sid throttle lbtot tracked type rate rate_lim rate_max check_status check_code check_duration hrsp_1xx hrsp_2xx hrsp_3xx hrsp_4xx hrsp_5xx hrsp_other hanafail req_rate req_rate_max req_tot cli_abrt srv_abrt"
 	local TABLE_HEADER="Host|25 Backend|15 Status Active Rate 1xx 2xx 3xx 4xx 5xx Ping"
 	local TABLE_VARS="svname|25 pxname|15 status scur req_rate hrsp_1xx hrsp_2xx hrsp_3xx hrsp_4xx hrsp_5xx check_duration"
-	if ! echo "show stat" | nc -U $SOCKET > /dev/null 2>&1; then
+	if ! show_stat $SOCKET > /dev/null 2>&1; then
 		echo "Unable to connect to HAProxy, ensure it is running!"
 		return
 	fi
@@ -96,18 +107,18 @@ status() {
 		printf "%-${SIZE}s |" $NAME
 	done
 	echo
-	echo "show stat" | nc -U $SOCKET \
+	show_stat $SOCKET \
 	  | while IFS=',' read ${STATS}; do
 		if [ -z "$svname" ]; then
 			continue
 		fi
-		if [ "$svname" == 'svname' ]; then
+		if [ "$svname" = 'svname' ]; then
 			continue
 		fi
-		if [ "$svname" == 'BACKEND' ]; then
+		if [ "$svname" = 'BACKEND' ]; then
 			continue
 		fi
-		if [ "$svname" == 'FRONTEND' ]; then
+		if [ "$svname" = 'FRONTEND' ]; then
 			continue
 		fi
 		echo -n "|"
@@ -120,7 +131,7 @@ status() {
 				SIZE=6
 			fi
 			eval VALUE=\$$NAME
-			if [ "${VAR}" == 'check_duration' ]; then
+			if [ "${VAR}" = 'check_duration' ]; then
 				VALUE="${VALUE}ms"
 			fi
 			printf "%-${SIZE}s |" ${VALUE:-0}

--- a/system/systemd/kazoo-haproxy.service
+++ b/system/systemd/kazoo-haproxy.service
@@ -14,6 +14,7 @@ ExecStart=/usr/sbin/kazoo-haproxy start
 ExecReload=/bin/kill -USR2 $MAINPID
 ExecStop=/usr/sbin/kazoo-haproxy stop
 Restart=on-abort
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Summary
=======

The following portability issues are addressed in these commits:

1. Specifying the shebang as `#!/bin/sh` and then using Bashisms
2. Mixing Bashisms and sh
3. A clash between the meaning of `nc` on Debian and CentOS, and `ncat -U` hanging in Debian `ncat`.
4. The systemd service not killing haproxy properly.

Bashisms
--------
Running `systemctl start kazoo-haproxy` on Debian 8 resulted in this
error:

    /usr/sbin/kazoo-haproxy: 51: [: root: unexpected operator

The reason for the error is that the script's shebang is `#!/bin/sh`,
which has different behavior on Debian 8 compared to CentOS 7.

In CentOS 7, `/bin/sh` is symlinked to `/bin/bash`, but on Debian 8,
it's symlinked to `/bin/dash`, which behaves more like the original
Bourne shell, `sh`.

See [HTMBSWID][How to make Bash scripts work in dash] for detail.

`sh` (and `dash`) supports `=`, but not `==`, as a string comparison
operator, hence one error.

Furthermore, `bash` does not allow `==`

This part of the commit does the following:

1. Change all occurrences of `==` to`=`
2. Change the shebang to `#!/bin/bash`

`nc` vs `ncat`
--------------

- On CentOS, `nc` is another way of running `ncat`.
- On Debian, `nc` is `netcat`, a totally different utility.

Debian `ncat` seems to hang when used in `kazoo-haproxy`. After some
debugging and research, replacing the use of

    ncat -U ${SOCKET}

with

    socat stdio unix-connect:${SOCKET}

seems to work perfectly in both Debian and CentOS, so this commit adopts
the use of `socat`.

systemd service
----------------
This commit adds `KillMode=mixed` to the `kazoo-haproxy` service because there were issues in Debian where haproxy was not being killed during `systemctl stop kazoo-haproxy` and multiple instances of haproxy were being started as a consequence when starting `kazoo-haproxy`.

[HTMBSWID]: http://mywiki.wooledge.org/Bashism