### PR TITLE
Switch to use the 'bind' keyword for listening addresses instead of l…

### DIFF
--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -21,20 +21,23 @@ defaults
         timeout client 12000ms
         timeout server 12000ms
         
-listen bigcouch-data 127.0.0.1:15984
+listen bigcouch-data
+  bind 127.0.0.1:15984
   balance roundrobin
     server db1.zone1.mydomain.com 127.0.0.1:5984 check
     server db2.zone1.mydomain.com 127.0.0.2:5984 check
     server db3.zone2.mydomain.com 127.0.0.3:5984 check backup
     server db4.zone2.mydomain.com 127.0.0.4:5984 check backup
 
-listen bigcouch-mgr 127.0.0.1:15986
+listen bigcouch-mgr
+  bind 127.0.0.1:15986
   balance roundrobin
     server db1.zone1.mydomain.com 127.0.0.1:5986 check
     server db2.zone1.mydomain.com 127.0.0.2:5986 check
     server db3.zone2.mydomain.com 127.0.0.3:5986 check backup
     server db4.zone2.mydomain.com 127.0.0.4:5986 check backup
 
-listen haproxy-stats 127.0.0.1:22002
+listen haproxy-stats
+  bind 127.0.0.1:22002
   mode http
   stats uri /


### PR DESCRIPTION
Switch to use the 'bind' keyword for listening addresses instead of listen arguments due to deprecation.
This allows newer version of haproxy to be ran such as 1.8, while still compatibile with version 1.5.